### PR TITLE
Fixed some entries in paper.bib

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -1,21 +1,21 @@
 @article{Bendall,
-  title={Single-cell mass cytometry of differential immune and drug responses across a human hematopoietic continuum},
-  author={Bendall SC, Simonds EF, Qiu P, Amir el-AD, Krutzik PO, Finck R, Bruggner RV, Melamed R, Trejo A, Ornatsky OI, Balderas RS, Plevritis SK, Sachs K, Pe'er D, Tanner SD, Nolan GP.},
-  journal={Science},
-  volume={332},
-  number={6030},
-  pages={687-696},
-  year={2011},
-  publisher={American Association for the Advancement of Science},
-  doi={10.1126/science.1198704}
+  doi = {10.1126/science.1198704},
+  year  = {2011},
+  publisher = {American Association for the Advancement of Science ({AAAS})},
+  volume = {332},
+  number = {6030},
+  pages = {687--696},
+  author = {S. C. Bendall and E. F. Simonds and P. Qiu and E.-a. D. Amir and P. O. Krutzik and R. Finck and R. V. Bruggner and R. Melamed and A. Trejo and O. I. Ornatsky and R. S. Balderas and S. K. Plevritis and K. Sachs and D. Pe{\textquotesingle}er and S. D. Tanner and G. P. Nolan},
+  title = {Single-Cell Mass Cytometry of Differential Immune and Drug Responses Across a Human Hematopoietic Continuum},
+  journal = {Science}
 }
 
 @article{Cytobank,
   title={Web-based Analysis and Publication of Flow Cytometry Experiments},
-  author={Kotecha N, Krutzik PO, Irish JM.},
+  author={N Kotecha and PO Krutzik and JM Irish},
   journal={Current Protocols in Cytometry},
   volume={53},
-  number={10},
+  number={1},
   pages={17:10.17.1–-10.17.24},
   year={2010},
   publisher={Wiley Online Library},
@@ -23,16 +23,16 @@
 }
 
 @Manual{CytobankAPI,
-  title = {CytobankAPI: Cytobank API Wrapper for R},
-  author = {Preston NG, Ciccolella C.},
+  title = {{CytobankAPI}: {Cytobank} {API} Wrapper for {R}},
+  author = {NG Preston and C Ciccolella},
   year = {2017},
   note = {R package version 1.1.0},
   url = {https://cran.r-project.org/web/packages/CytobankAPI/},
 }
 
 @article{polyarticularJIA,
-  title={Identification of enhanced IFN-γ signaling in polyarticular juvenile idiopathic arthritis with mass cytometry},
-  author={Throm AA, Moncrieffe H, Orandi AB, Pingel JT, Geurs TL, Miller HL, Daugherty AL, Malkova OM, Lovell DJ, Thompson SD, Grom AA, Cooper MA, Oh ST, French AR.},
+  title = {Identification of enhanced {IFN}-$\gamma$ signaling in polyarticular juvenile idiopathic arthritis with mass cytometry},
+  author = {Allison A. Throm and Halima Moncrieffe and Amir B. Orandi and Jeanette T. Pingel and Theresa L. Geurs and Hannah L. Miller and Allyssa L. Daugherty and Olga N. Malkova and Daniel J. Lovell and Susan D. Thompson and Alexei A. Grom and Megan A. Cooper and Stephen T. Oh and Anthony R. French},
   journal={JCI Insight},
   volume={3},
   number={15},
@@ -43,8 +43,8 @@
 }
 
 @article{JDM,
-  title={Identification of enhanced IFN-γ signaling in polyarticular juvenile idiopathic arthritis with mass cytometry},
-  author={Throm AA, Alinger JB, Pingel JT,  Daugherty AL, Pachman LM, French AR.},
+  title={Dysregulated {NK} cell {PLC}$\gamma$2 signaling and activity in juvenile dermatomyositis},
+  author={AA Throm and JB Alinger and JT Pingel and AL Daugherty and LM Pachman and AR French},
   journal={JCI Insight},
   volume={3},
   number={22},


### PR DESCRIPTION
Author names need to be separated with `and`, and curly brackets put around things in titles to retain capitalization. Also, the JDM paper didn't have the correct title (looked the same as polyarticularJIA)